### PR TITLE
Undefined name: import scipy in Lenia.py

### DIFF
--- a/Python/Lenia.py
+++ b/Python/Lenia.py
@@ -1,5 +1,6 @@
 import numpy as np                          # pip3 install numpy
-import scipy.ndimage as snd                 # pip3 install scipy
+import scipy                                # pip3 install scipy
+import scipy.ndimage as snd
 import reikna.fft, reikna.cluda             # pip3 install pyopencl/pycuda, reikna
 from PIL import Image, ImageTk, ImageDraw   # pip3 install pillow
 try: import tkinter as tk


### PR DESCRIPTION
__scipy__ is used twice but is never imported or defined.

flake8 testing of https://github.com/Chakazul/Lenia on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./Python/Lenia.py:446:7: F821 undefined name 'scipy'
		d = scipy.spatial.distance.pdist(self.series[:, None])
      ^
./Python/Lenia.py:449:7: F821 undefined name 'scipy'
		Z = scipy.spatial.distance.squareform(d)
      ^
./Python/Lenia.py:1078:89: F821 undefined name 'text'
		self.menu.children[info[0]].entryconfig(info[1], label='{text} [{value}]'.format(text=text if text else info[2], value=value))
                                                                                        ^
./Python/Lenia.py:1078:97: F821 undefined name 'text'
		self.menu.children[info[0]].entryconfig(info[1], label='{text} [{value}]'.format(text=text if text else info[2], value=value))
                                                                                                ^
4     F821 undefined name 'scipy'
4
```

The other two issues are worth looking at as well.  There is no variable __text__ defined within that context which may raise NameError at runtime.